### PR TITLE
Rails3 automatically escaping render_audits

### DIFF
--- a/lib/simple_audit/helper.rb
+++ b/lib/simple_audit/helper.rb
@@ -19,13 +19,14 @@ module SimpleAudit #:nodoc:
                 "\n" + 
                 audited_model.class.human_attribute_name(k) +
                 ":" +
-                content_tag(:span, v.last, :class => 'current') +
-                content_tag(:span, v.first, :class => 'previous') 
+                content_tag(:span, v.last, :class => 'current')+
+                content_tag(:span, v.first, :class => 'previous')
+                 
               end
             else
               audit.change_log.reject{|k, v| v.blank?}.collect {|k, v| "\n#{audited_model.class.human_attribute_name(k)}: #{v}"}
             end
-            changes.join    
+            raw( changes.join )
           end        
         end
       end


### PR DESCRIPTION
Hi, 

I am new to rails so there may be a much better way to handle this, but this seems to be working for me locally.  If I use render_audits like this : raw( render_audits( @model ) ) it works mostly, but the actual delta changes are doubly escaped, so even with raw they are still escaped and not being included as HTML.

I found that if I encapsulated changes.join in the render_audits method it solved the problem.  This might benefit other rails3 devs.

If there is a better way please do tell me, I am keen to learn more.

Also, your audit trails work really well, I like the rendered deltas as well, very slick.

Cheers,
Vince
vfilby@gmail.com
